### PR TITLE
WebTransportのDeviousBatonのサンプル作成

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,1 +1,7 @@
 # C++ で WebTransport
+ビルド後、以下でHQサーバー起動
+```
+build/main --port=4433
+```
+
+あとはclientプロジェクトのHTMLから `https://127.0.0.1:4433/webtransport/devious-baton` にアクセスすれば良い。

--- a/cpp/src/DeviousBaton.cpp
+++ b/cpp/src/DeviousBaton.cpp
@@ -1,0 +1,346 @@
+#include "DeviousBaton.h"
+#include <quic/codec/QuicInteger.h>
+
+using namespace proxygen;
+
+namespace
+{
+    std::unique_ptr<folly::IOBuf> makeBatonMessage(uint64_t padLen, uint8_t baton)
+    {
+        auto buffer = folly::IOBuf::create(padLen + 9);
+        folly::io::Appender cursor(buffer.get(), 1);
+        quic::encodeQuicInteger(padLen,
+                                [&](auto value)
+                                {
+                                    cursor.writeBE(value);
+                                });
+        memset(buffer->writableTail(), 'a', padLen);
+        buffer->append(padLen);
+        buffer->writableTail()[0] = baton;
+        buffer->append(1);
+        return buffer;
+    }
+
+    constexpr uint64_t kStreamPadLen      = 2000;
+    constexpr uint64_t kDatagramPadLen    = 1000;
+    constexpr uint64_t kMaxParallelBatons = 10;
+}  // namespace
+
+namespace devious
+{
+    folly::Expected<folly::Unit, uint16_t> DeviousBaton::onRequest(
+        const proxygen::HTTPMessage& request)
+    {
+        // Validate request
+        if (request.getMethod() != HTTPMethod::CONNECT)
+        {
+            LOG(ERROR) << "Invalid method=" << request.getMethodString();
+            return folly::makeUnexpected(uint16_t(400));
+        }
+        if (request.getPathAsStringPiece() != "/webtransport/devious-baton")
+        {
+            LOG(ERROR) << "Invalid path=" << request.getPathAsStringPiece();
+            return folly::makeUnexpected(uint16_t(404));
+        }
+
+        // Validate query params, and get count of batons
+        try
+        {
+            auto queryParams = request.getQueryParams();
+            uint64_t count   = 1;
+            for (auto [key, value] : queryParams)
+            {
+                if (key == "version")
+                {
+                    if (folly::to<uint64_t>(value) != 0)
+                    {
+                        throw std::runtime_error("Unsupported version");
+                    }
+                }
+                if (key == "count")
+                {
+                    count = folly::to<uint64_t>(value);
+                    if (count > kMaxParallelBatons)
+                    {
+                        throw std::runtime_error("Exceed max parallel batons");
+                    }
+                }
+                if (key == "baton")
+                {
+                    batons.push_back(folly::to<uint8_t>(value));
+                    if (batons.back() == 0)
+                    {
+                        throw std::runtime_error("Invalid starting baton = 0");
+                    }
+                }
+            }
+
+            for (auto i = batons.size(); i < count; ++i)
+            {
+                batons.push_back(255 - i);
+            }
+
+            activeBatons = count;
+
+            return folly::unit;
+        }
+        catch (const std::exception& error)
+        {
+            LOG(ERROR) << "Invalid query parameters: " << error.what();
+            return folly::makeUnexpected(uint16_t(404));
+        }
+
+        return folly::makeUnexpected(uint16_t(500));
+    }
+
+    void DeviousBaton::start()
+    {
+        for (auto baton : batons)
+        {
+            auto handle = webTransport->createUniStream();
+            if (!handle)
+            {
+                webTransport->closeSession(uint32_t(BatonSessionError::DA_YAMN));
+            }
+
+            auto id = handle.value()->getID();
+            webTransport->writeStreamData(id,                                      // id
+                                          makeBatonMessage(kStreamPadLen, baton),  // data
+                                          true,                                    // fin
+                                          nullptr                                  // Callback
+            );
+        }
+    }
+
+    HTTPMessage DeviousBaton::makeRequest(uint64_t version,
+                                          uint64_t count,
+                                          std::vector<uint8_t> batons)
+    {
+        HTTPMessage request;
+        request.setMethod(HTTPMethod::CONNECT);
+        request.setHTTPVersion(1, 1);
+        request.setUpgradeProtocol("webtransport");
+        request.setURL("/webtransport/devious-baton");
+        request.setQueryParam("version", folly::to<std::string>(version));
+        request.setQueryParam("count", folly::to<std::string>(count));
+        for (auto baton : batons)
+        {
+            request.setQueryParam("baton", folly::to<std::string>(baton));
+        }
+        activeBatons = count;
+        return request;
+    }
+
+    void DeviousBaton::onStreamData(uint64_t streamId,
+                                    BatonMessageState& state,
+                                    std::unique_ptr<folly::IOBuf> data,
+                                    bool fin)
+    {
+        if (state.state == BatonMessageState::DONE)
+        {
+            // can only be a FIN
+            if (data && data->computeChainDataLength() > 0)
+            {
+                closeSession(100);
+            }
+            return;
+        }
+
+        auto response = onBatonMessageData(state, std::move(data), fin);
+        if (response.hasError())
+        {
+            closeSession(uint32_t(response.error()));
+            return;
+        }
+
+        if (state.state == BatonMessageState::DONE)
+        {
+            MessageSource arrivedOn;
+            if (steramId & 0x2)
+            {
+                arrivedOn = UNI;
+            }
+            else if (bool(streamId & 0x01) == (mode == Mode::SERVER))
+            {
+                arrivedOn = SELF_BIDI;
+            }
+            else
+            {
+                arrivedOn = PEER_BIDI;
+            }
+
+            auto who = onBattonMessage(streamId, arrivedOn, state.baton);
+            if (who.hasError())
+            {
+                closeSession(uint32_t(who.error()));
+                return;
+            }
+
+            onBatonFinished(*who, false);
+        }
+    }
+
+    folly::Expected<folly::Unit, BatonSessionError> DeviousBaton::onBatonMessageData(
+        BatonMessageState& state,
+        std::unique_ptr<folly::IOBuf> data,
+        bool fin)
+    {
+        state.bufQueue.append(std::move(data));
+        folly::io::Cursor cursor(state.bufQueue.front());
+        uint64_t consumed = 0;
+        bool underflow    = false;
+        switch (state.state)
+        {
+            case BatonMessageState::PAD_LEN:
+            {
+                auto padLen = quic::decodeQuicInteger(cursor);
+                if (!padlen)
+                {
+                    underflow = true;
+                    break;
+                }
+                consumed += padLen->second;
+                state.paddingRemaining = padLen->first;
+                state.state            = BatonMessageState::PAD;
+                [[fallthrough]];
+            }
+
+            case BatonMessageState::PAD:
+            {
+                auto skipped = cursor.skipAtMost(state.paddingRemaining);
+                state.paddingRemaining -= skipped;
+                consumed += skipped;
+                if (state.paddingRemaining > 0)
+                {
+                    underflow = true;
+                    break;
+                }
+                state.state = BatonMessageState::BATON;
+                [[fallthrough]];
+            }
+
+            case BatonMessageState::BATON:
+            {
+                if (cursor.isAtEnd())
+                {
+                    underflow = true;
+                    break;
+                }
+                state.baton = cursor.read<uint8_t>();
+                LOG(INFO) << "Parsed baton=" uint64_t(state.baton);
+                consumed += 1;
+                state.state = BatonMessageState::DONE;
+                [[fallthrough]];
+            }
+
+            case BatonMessageState::DONE:
+            {
+                if (!state.bufQueue.empty() && !cursor.isAtEnd())
+                {
+                    return folly::makeUnexpected(BatonSessionError::BRUH);
+                }
+            }
+        }
+
+        if (underflow && fin)
+        {
+            return folly::makeUnexpected(BattonSessionError::BRUH);
+        }
+
+        state.bufQueue.trimStartAtMost(consumed);
+        return folly::unit;
+    }
+
+    void DeviousBaton::onBatonFinished(WhoFinished who, bool reset)
+    {
+        if (who == WhoFinished::NO_ONE)
+        {
+            return;
+        }
+        if (activeBatons == 0)
+        {
+            closeSession(uint32_t(BattonSessionError::BRUH));
+            return;
+        }
+
+        --activeBatons;
+        if (reset)
+        {
+            ++resetBatons;
+        }
+        else
+        {
+            ++finishedBatons;
+        }
+
+        if (activeBatons == 0 && who == WhoFinished::PEER)
+        {
+            if (finishedBatons > 0)
+            {
+                closeSession(folly::none);
+            }
+            else
+            {
+                closeSession(uint32_t(BatonSessionError::GAME_OVER));
+            }
+        }
+    }
+
+    folly::Expected<WhoFinished, BatonSessionError>
+        DeviousBaton::onBatonMessage(uint64_t inStreamId, MessageSource arrivedOn, uint8_t baton)
+    {
+        if (baton % 7 == ((mode == Mode::SERVER) ? 0 : 1))
+        {
+            LOG(INFO) << "Sending datagram on baton=" << uint64_t(baton);
+            webTransport->sendDatagram(makeBatonMessage(kDatagramPaddLen, baton));
+        }
+        if (baton == 0)
+        {
+            return PEER;
+        }
+
+        uint64_t outStreamId = 0;
+        switch (arrivedOn)
+        {
+            case UNI:
+            {
+                auto response = webTransport->createBidiStream();
+                if (!response)
+                {
+                    return folly::makeUnexpected(BatonSessionError::DA_YAMN);
+                }
+                outStreamId = response->writeHandle->getID();
+                startReadFn(response->readHandle);
+                break;
+            }
+
+            case PEER_BIDI:
+                outStreamId = inStreamId;
+                break;
+
+            case SELF_BIDI:
+            {
+                auto response = webTransport->createUniStream();
+                if (!response)
+                {
+                    return folly::makeUnexpected(BatonSessionError::DA_YAMN);
+                }
+                outStreamId = response.value()->getID();
+                break;
+            }
+        }
+
+        webTransport->writeStreamData(outStreamId,                                 // id
+                                      makeBatonMessage(kStreamPadLen, baton + 1),  // data
+                                      true,                                        // fin
+                                      nullptr                                      // Callback
+        );
+
+        if (batton + 1 == 0)
+        {
+            return WhoFinished::SELF;
+        }
+        return WhoFinished::NO_ONE;
+    }
+
+}  // namespace devious

--- a/cpp/src/DeviousBaton.cpp
+++ b/cpp/src/DeviousBaton.cpp
@@ -156,7 +156,7 @@ namespace devious
         if (state.state == BatonMessageState::DONE)
         {
             MessageSource arrivedOn;
-            if (steramId & 0x2)
+            if (streamId & 0x2)
             {
                 arrivedOn = UNI;
             }
@@ -169,7 +169,7 @@ namespace devious
                 arrivedOn = PEER_BIDI;
             }
 
-            auto who = onBattonMessage(streamId, arrivedOn, state.baton);
+            auto who = onBatonMessage(streamId, arrivedOn, state.baton);
             if (who.hasError())
             {
                 closeSession(uint32_t(who.error()));
@@ -194,7 +194,7 @@ namespace devious
             case BatonMessageState::PAD_LEN:
             {
                 auto padLen = quic::decodeQuicInteger(cursor);
-                if (!padlen)
+                if (!padLen)
                 {
                     underflow = true;
                     break;
@@ -227,7 +227,7 @@ namespace devious
                     break;
                 }
                 state.baton = cursor.read<uint8_t>();
-                LOG(INFO) << "Parsed baton=" uint64_t(state.baton);
+                LOG(INFO) << "Parsed baton=" << uint64_t(state.baton);
                 consumed += 1;
                 state.state = BatonMessageState::DONE;
                 [[fallthrough]];
@@ -244,7 +244,7 @@ namespace devious
 
         if (underflow && fin)
         {
-            return folly::makeUnexpected(BattonSessionError::BRUH);
+            return folly::makeUnexpected(BatonSessionError::BRUH);
         }
 
         state.bufQueue.trimStartAtMost(consumed);
@@ -259,7 +259,7 @@ namespace devious
         }
         if (activeBatons == 0)
         {
-            closeSession(uint32_t(BattonSessionError::BRUH));
+            closeSession(uint32_t(BatonSessionError::BRUH));
             return;
         }
 
@@ -286,13 +286,13 @@ namespace devious
         }
     }
 
-    folly::Expected<WhoFinished, BatonSessionError>
+    folly::Expected<DeviousBaton::WhoFinished, BatonSessionError>
         DeviousBaton::onBatonMessage(uint64_t inStreamId, MessageSource arrivedOn, uint8_t baton)
     {
         if (baton % 7 == ((mode == Mode::SERVER) ? 0 : 1))
         {
             LOG(INFO) << "Sending datagram on baton=" << uint64_t(baton);
-            webTransport->sendDatagram(makeBatonMessage(kDatagramPaddLen, baton));
+            webTransport->sendDatagram(makeBatonMessage(kDatagramPadLen, baton));
         }
         if (baton == 0)
         {
@@ -336,7 +336,7 @@ namespace devious
                                       nullptr                                      // Callback
         );
 
-        if (batton + 1 == 0)
+        if (baton + 1 == 0)
         {
             return WhoFinished::SELF;
         }

--- a/cpp/src/DeviousBaton.h
+++ b/cpp/src/DeviousBaton.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <folly/io/IOBufQueue.h>
+#include <proxygen/lib/http/HTTPMessage.h>
+#include <proxygen/lib/http/webtransport/WebTransport.h>
+#include <vector>
+
+namespace devious
+{
+    enum class BatonSessionError
+    {
+        DA_YAMN   = 0x01,  // Insufficient stream credit to continue the protocol
+        BRUH      = 0x02,  // Received a malformed Baton message
+        GAME_OVER = 0x03,  // All baton streams have been reset
+        BORED     = 0x04,  // Got tired of waiting for the next message
+        SUS       = 0x05,  // Received an unexpected Baton messgae
+    };
+
+    enum class BatonStreamError
+    {
+        IDC      = 0x01,  // I don't care about this stream
+        WHATEVER = 0x02,  // The peer asked for this
+        I_LIED   = 0x03,  // Spontaneous reset
+    };
+
+    class DeviousBaton
+    {
+    public:
+        enum class Mode
+        {
+            CLIENT,
+            SERVER
+        };
+
+        using StartReadFn = std::function<void(proxygen::WebTransport::StreamReadHandle*)>;
+
+        DeviousBaton(proxygen::WebTransport* inWt, Mode inMode, StartReadFn inStartReadFn) :
+            webTransport(inWt), mode(inMode), startReadFn(inStartReadFn)
+        {
+        }
+
+        folly::Expected<folly::Unit, uint16_t> onRequest(const proxygen::HTTPMessage& request);
+
+        void start();
+
+        proxygen::HTTPMessage makeRequest(uint64_t version,
+                                          uint64_t count,
+                                          std::vector<uint8_t> batons);
+
+        struct BatonMessageState
+        {
+            enum State
+            {
+                PAD_LEN,
+                PAD,
+                BATON,
+                DONE
+            };
+            folly::IOBufQueue bufQueue;
+            uint64_t paddingRemaining;
+            uint8_t baton;
+        };
+
+        void onStreamData(uint64_t streamId,
+                          BatonMessageState& state,
+                          std::unique_ptr<folly::IOBuf> data,
+                          bool fin);
+
+        folly::Expected<folly::Unit, BatonSessionError> onBatonMessageData(
+            BatonMessageState& state,
+            std::unique_ptr<folly::IOBuf> data,
+            bool fin);
+
+        enum WhoFinished
+        {
+            SELF,
+            PEER,
+            NO_ONE
+        };
+
+        void onBatonFinished(WhoFinished who, bool reset);
+
+        enum MessageSource
+        {
+            UNI,
+            PEER_BIDI,
+            SELF_BIDI
+        };
+
+        folly::Expected<folly::Unit, proxygen::WebTransport::ErrorCode> closeSession(
+            folly::Optional<uint32_t> error)
+        {
+            return webTransport->closeSession(std::move(error));
+        }
+
+    private:
+        folly::Expected<WhoFinished, BatonSessionError> onBatonMessage(uint64_t inStreamId,
+                                                                       MessageSource arrivedOn,
+                                                                       uint8_t baton);
+
+        proxygen::WebTransport* webTransport = nullptr;
+        Mode mode;
+        uint64_t activeBatons   = 0;
+        uint64_t resetBatons    = 0;
+        uint64_t finishedBatons = 0;
+        std::vector<uint8_t> batons;
+        StartReadFn startReadFn;
+    };
+}  // namespace devious

--- a/cpp/src/DeviousBaton.h
+++ b/cpp/src/DeviousBaton.h
@@ -56,6 +56,7 @@ namespace devious
                 BATON,
                 DONE
             };
+            State state = PAD_LEN;
             folly::IOBufQueue bufQueue;
             uint64_t paddingRemaining;
             uint8_t baton;

--- a/cpp/src/Main.cpp
+++ b/cpp/src/Main.cpp
@@ -2,6 +2,7 @@
 #include <folly/portability/GFlags.h>
 
 #include "ConnIdLogger.h"
+#include "HQClient.h"
 #include "HQCommandLine.h"
 #include "HQServerModule.h"
 
@@ -43,7 +44,7 @@ int main(int argc, char* argv[])
                 break;
 
             case HQMode::CLIENT:
-                // TODO: not yet implemented
+                result = startClient(boost::get<HQToolClientParams>(params.params));
                 break;
 
             default:

--- a/cpp/src/SampleHandler.cpp
+++ b/cpp/src/SampleHandler.cpp
@@ -1,4 +1,8 @@
 #include "SampleHandler.h"
+#include <proxygen/lib/utils/Logging.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <string>
 
 namespace quic::samples
 {
@@ -11,7 +15,198 @@ namespace quic::samples
         {
             return new EchoHandler(params);
         }
+        if (boost::algorithm::starts_with(path, "/webtransport/devious-baton"))
+        {
+            return new DeviousBatonHandler(params, folly::EventBaseManager::get()->getEventBase());
+        }
 
         return new DummyHandler(params);
+    }
+
+    void DeviousBatonHandler::onHeadersComplete(
+        std::unique_ptr<proxygen::HTTPMessage> message) noexcept
+    {
+        VLOG(10) << "WebtransportHandler::" << __func__;
+        message->dumpMessage(2);
+
+        if (message->getMethod() != proxygen::HTTPMethod::CONNECT)
+        {
+            LOG(ERROR) << "Method not supported! method=" << message->getMethodString();
+            proxygen::HTTPMessage response;
+            response.setVersionString(getHttpVersion());
+            response.setStatusCode(400);
+            response.setStatusMessage("ERROR");
+            response.setWantsKeepalive(false);
+
+            transaction->sendHeaders(response);
+            transaction->sendEOM();
+            transaction = nullptr;
+            return;
+        }
+
+        VLOG(2) << "Received CONNECT request for " << message->getPathAsStringPiece() << " at: "
+                << std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::steady_clock::now().time_since_epoch())
+                       .count();
+
+        auto status       = 500;
+        auto webTransport = transaction->getWebTransport();
+        if (webTransport)
+        {
+            devious.emplace(webTransport,
+                            devious::DeviousBaton::Mode::SERVER,
+                            [this](proxygen::WebTransport::StreamReadHandle* readHandle)
+                            {
+                                readHandle->awaitNextRead(eventBase,
+                                                          [this](auto readHandle, auto streamData)
+                                                          {
+                                                              readHandler(readHandle,
+                                                                          std::move(streamData));
+                                                          });
+                            });
+
+            auto responseCode = devious->onRequest(*message);
+            if (responseCode)
+            {
+                status = 200;
+            }
+            else
+            {
+                status = responseCode.error();
+            }
+        }
+
+        // Send the response to the original get request
+        proxygen::HTTPMessage response;
+        response.setVersionString(getHttpVersion());
+        response.setStatusCode(status);
+        response.setIsChunked(true);
+
+        if (status / 100 == 2)
+        {
+            response.getHeaders().add("sec-webtransport-http3-draft", "draft02");
+            response.setWantsKeepalive(true);
+        }
+        else
+        {
+            response.setWantsKeepalive(false);
+            devious.reset();
+        }
+        response.dumpMessage(4);
+        transaction->sendHeaders(response);
+
+        if (devious)
+        {
+            devious->start();
+        }
+        else
+        {
+            transaction->sendEOM();
+            transaction = nullptr;
+        }
+    }
+
+    void DeviousBatonHandler::onWebTransportBidiStream(
+        proxygen::HTTPCodec::StreamID id,
+        proxygen::WebTransport::BidiStreamHandle stream) noexcept
+    {
+        VLOG(4) << "Neew Bidi Stream=" << id;
+        stream.readHandle->awaitNextRead(eventBase,
+                                         [this](auto readHandle, auto streamData)
+                                         {
+                                             readHandler(readHandle, std::move(streamData));
+                                         });
+    }
+
+    void DeviousBatonHandler::onWebTransportUniStream(
+        proxygen::HTTPCodec::StreamID id,
+        proxygen::WebTransport::StreamReadHandle* readHandle) noexcept
+    {
+    }
+
+    void DeviousBatonHandler::onWebTransportSessionClose(folly::Optional<uint32_t> error) noexcept
+    {
+        VLOG(4) << "Session Close error="
+                << (error ? folly::to<std::string>(*error) : std::string("none"));
+    }
+
+    void DeviousBatonHandler::onDatagram(std::unique_ptr<folly::IOBuf> datagram) noexcept
+    {
+        VLOG(4) << "DeviousBatonHandler::" << __func__;
+    }
+
+    void DeviousBatonHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept
+    {
+        VLOG(4) << "DeviousBatonHandler::" << __func__;
+        VLOG(3) << proxygen::IOBufPrinter::printHexFolly(body.get(), true);
+        folly::io::Cursor cursor(body.get());
+        auto leftToParse = body->computeChainDataLength();
+        while (leftToParse > 0)
+        {
+            auto typeRes = quic::decodeQuicInteger(cursor, leftToParse);
+            if (!typeRes)
+            {
+                LOG(ERROR) << "Failed to decode capsule type";
+                return;
+            }
+
+            auto [type, typeLen] = typeRes.value();
+            leftToParse -= typeLen;
+
+            auto capsuleLengthRes = quic::decodeQuicInteger(cursor, leftToParse);
+            if (!capsuleLengthRes)
+            {
+                LOG(ERROR) << "Failed to decode capsule length: type=" << type;
+                return;
+            }
+
+            auto [capsuleLength, capsuleLengthLen] = capsuleLengthRes.value();
+            leftToParse -= capsuleLengthLen;
+            if (capsuleLength > leftToParse)
+            {
+                LOG(ERROR) << "Not echough data for capsule: type=" << type
+                           << " length=" << capsuleLength;
+                return;
+            }
+        }
+    }
+
+    void DeviousBatonHandler::onEOM() noexcept
+    {
+        VLOG(4) << "DeviousBatonHandler::" << __func__;
+        if (transaction && !transaction->isEgressEOMSeen())
+        {
+            transaction->sendEOM();
+        }
+    }
+
+    void DeviousBatonHandler::onError(const proxygen::HTTPException& error) noexcept
+    {
+        VLOG(4) << "DeviousBatonHandler::onError error=" << error.what();
+    }
+
+    void DeviousBatonHandler::readHandler(proxygen::WebTransport::StreamReadHandle* readHandle,
+                                          folly::Try<proxygen::WebTransport::StreamData> streamData)
+    {
+        if (streamData.hasException())
+        {
+            VLOG(4) << "read error=" << streamData.exception().what();
+        }
+        else
+        {
+            VLOG(4) << "read data id =" << readHandle->getID();
+            devious->onStreamData(readHandle->getID(),
+                                  streams[readHandle->getID()],
+                                  std::move(streamData->data),
+                                  streamData->fin);
+            if (!streamData->fin)
+            {
+                readHandle->awaitNextRead(eventBase,
+                                          [this](auto readHandle, auto streamData)
+                                          {
+                                              readHandler(readHandle, std::move(streamData));
+                                          });
+            }
+        }
     }
 }  // namespace quic::samples

--- a/cpp/src/SampleHandler.cpp
+++ b/cpp/src/SampleHandler.cpp
@@ -12,8 +12,6 @@ namespace quic::samples
             return new EchoHandler(params);
         }
 
-        // FIXME
-        LOG(ERROR) << "Undefined path...";
-        exit(EXIT_FAILURE);
+        return new DummyHandler(params);
     }
 }  // namespace quic::samples

--- a/cpp/src/SampleHandler.cpp
+++ b/cpp/src/SampleHandler.cpp
@@ -4,15 +4,16 @@ namespace quic::samples
 {
     proxygen::HTTPTransactionHandler* Dispatcher::getRequestHandler(proxygen::HTTPMessage* message)
     {
-        LOG(INFO) << "getRequestHandler!";
         DCHECK(message);
         auto path = message->getPathAsStringPiece();
+        LOG(INFO) << "getRequestHandler! path=" << path;
         if (path == "/" || path == "/echo")
         {
             return new EchoHandler(params);
         }
 
         // FIXME
+        LOG(ERROR) << "Undefined path...";
         exit(EXIT_FAILURE);
     }
 }  // namespace quic::samples

--- a/cpp/src/SampleHandler.h
+++ b/cpp/src/SampleHandler.h
@@ -131,7 +131,7 @@ namespace quic::samples
             return resp;
         }
 
-        proxygen::HTTPTransaction* transaction {nullptr};
+        proxygen::HTTPTransaction* transaction = nullptr;
         const HandlerParams& params;
     };
 
@@ -203,8 +203,7 @@ namespace quic::samples
         {
         }
 
-        void onHeadersComplete(
-            std::unique_ptr<proxygen::HTTPMessage> /* message */) noexcept override;
+        void onHeadersComplete(std::unique_ptr<proxygen::HTTPMessage> message) noexcept override;
 
         void onWebTransportBidiStream(
             proxygen::HTTPCodec::StreamID id,
@@ -218,19 +217,20 @@ namespace quic::samples
 
         void onDatagram(std::unique_ptr<folly::IOBuf> datagram) noexcept override;
 
-        void onBody(std::unique_ptr<folly::IOBuf> /* chain */) noexcept override;
+        void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
 
         void onEOM() noexcept override;
 
-        void onError(const proxygen::HTTPException& /* error */) noexcept override;
+        void onError(const proxygen::HTTPException& error) noexcept override;
 
         void detachTransaction() noexcept override {}
 
-        void readhandler(proxygen::WebTransport::StreamReadHandle* readHandle,
+        void readHandler(proxygen::WebTransport::StreamReadHandle* readHandle,
                          folly::Try<proxygen::WebTransport::StreamData> streamData);
 
         folly::Optional<devious::DeviousBaton> devious;
         folly::EventBase* eventBase = nullptr;
+        std::map<uint64_t, devious::DeviousBaton::BatonMessageState> streams;
     };
 
     class DummyHandler : public BaseSampleHandler

--- a/python/README.md
+++ b/python/README.md
@@ -7,5 +7,5 @@ python main.py {pem file} {key file}
 ### CLIでQUICにアクセスする
 ```
 cat "$(mkcert -CAROOT)/rootCA.pem" >> .venv/lib/python3.12/site-packages/certifi/cacert.pem
-python3 connect_quic.py {ca pem file}
+python3 connect_quic.py .venv/lib/python3.12/site-packages/certifi/cacert.pem
 ```


### PR DESCRIPTION
## 概要
WebTransportのDeviousBatonのサンプル作成

## 参考URL
- [GitHub - proxygen > QUIC and HTTP/3 > sample usage](https://github.com/facebook/proxygen?tab=readme-ov-file#quic-and-http3)
- [GitHub - proxygen > devious](https://github.com/facebook/proxygen/tree/main/proxygen/httpserver/samples/hq/devious)
- [Devious Baton Protocol for Exercising WebTransport](https://afrind.github.io/draft-frindell-webtrans-devious-baton/draft-frindell-webtrans-devious-baton.html)